### PR TITLE
Amélioration de la méthode utilitaire::validerURLAgenda

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -89,12 +89,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.0-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -544,7 +544,7 @@
         },
         {
             "name": "twig/intl-extra",
-            "version": "v3.17.0",
+            "version": "v3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/intl-extra.git",
@@ -592,7 +592,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/intl-extra/tree/v3.17.0"
+                "source": "https://github.com/twigphp/intl-extra/tree/v3.18.0"
             },
             "funding": [
                 {
@@ -608,16 +608,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.17.1",
+            "version": "v3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "677ef8da6497a03048192aeeb5aa3018e379ac71"
+                "reference": "acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/677ef8da6497a03048192aeeb5aa3018e379ac71",
-                "reference": "677ef8da6497a03048192aeeb5aa3018e379ac71",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50",
+                "reference": "acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50",
                 "shasum": ""
             },
             "require": {
@@ -672,7 +672,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.17.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.18.0"
             },
             "funding": [
                 {
@@ -684,7 +684,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-12T09:58:10+00:00"
+            "time": "2024-12-29T10:51:50+00:00"
         }
     ],
     "packages-dev": [],

--- a/modeles/agenda.class.php
+++ b/modeles/agenda.class.php
@@ -248,24 +248,6 @@ class Agenda
     }
 
     /**
-     * tester la validité de l'URL d'un Agenda
-     *
-     * @param string|null $url de l'agenda a verifier
-     * @throws Exception erreur de l'url si il n'est pas valide
-     * @return boolean true si l'url est valide, false sinon
-     */
-    public function testerValiditeUrl(?string $url): bool
-    {
-        try {
-            // @ nécessaire pour enlever les erreurs
-            @$calendrier = new ICal($url);
-            return true;
-        } catch (Exception $e) {
-            return false;
-        }
-    }
-
-    /**
      * Fusionner les evenements récupérer afin d'avoir des évènements triés et fusionnés
      *
      * @param string|null $events évènements à triés et à fusionner

--- a/modeles/utilitaire.class.php
+++ b/modeles/utilitaire.class.php
@@ -5,6 +5,8 @@
  * @version 0.4
  */
 
+use ICal\ICal;
+
 class utilitaire {
     /**
      * Redimensionne une image
@@ -173,29 +175,30 @@ class utilitaire {
         // 3. Longueur de la chaine - non pertinent
 
         // 4. Format des données : vérifier le format de l'URL
-        if (!filter_var($urlAgenda, FILTER_VALIDATE_URL) && utilitaire::validerPreg($urlAgenda, '/^https?:\/\/calendar\.google\.com\/calendar\/ical\/.+\/basic\.ics$/', $messagesErreurs, "URL agenda")) {
+        if (!filter_var($urlAgenda, FILTER_VALIDATE_URL) && !utilitaire::validerPreg($urlAgenda, '/^https?:\/\/calendar\.google\.com\/calendar\/ical\/.+\/basic\.ics$/', $messagesErreurs, "URL agenda")) {
             $messagesErreurs[] = "L'URL de l'agenda n'est pas valide.";
             $valide = false;
         }
-
-        // Vérification du type MIME du fichier
-        $headers = get_headers($url, 1);
-        if (isset($headers['Content-Type'])) {
-            if (!strpos($headers['Content-Type'], 'text/calendar')) {
-                $messagesErreurs[] = "Le fichier obtenir à partir de l'URL n'est pas un agenda";
+        else {
+            // Vérification du type MIME du fichier
+            $headers = get_headers($urlAgenda, 1);
+            if (!isset($headers['Content-Type'])) {
+                $messagesErreurs[] = "Impossible de vérifier le type du fichier à partir de l'URL";
                 $valide = false;
             }
-            $messagesErreurs[] = "Impossible de vérifier le type du fichier à partir de l'URl";
-            $valide = false;
-        }
+            elseif (strpos($headers['Content-Type'], 'text/calendar') === false) {
+                $messagesErreurs[] = "Le fichier obtenu à partir de l'URL n'est pas un agenda";
+                $valide = false;
+            }
 
-        // Test de création de l'objet ICal à partir de l'URL
-        try {
-            // @ nécessaire pour enlever les erreurs
-            @$calendrier = new ICal($url);
-        } catch (Exception $e) {
-            $messagesErreurs[] = "Impossible d'importer les données ";
-            $valide = false;
+            // Test de création de l'objet ICal à partir de l'URL
+            try {
+                // @ nécessaire pour enlever les erreurs
+                @$calendrier = new ICal($urlAgenda);
+            } catch (Exception $e) {
+                $messagesErreurs[] = "Impossible d'importer les données ";
+                $valide = false;
+            }
         }
 
         return $valide;


### PR DESCRIPTION
Amélioration de la méthode utilitaire::validerURLAgenda de sorte à ce qu'elle vérifie additionnellement : 
 -  Que le type MIME du fichier récupéré est bien un calendrier (.ical, .ics, .ifb ou .icalendar)
 - Qu'il peut être instancié par la classe ICal de ICS Parser

L'ancienne méthode du contrôleur agenda (pas utilisé) a été supprimé