### PR TITLE
Support universel agenda

### DIFF
--- a/js/formulaireCreationAgenda.js
+++ b/js/formulaireCreationAgenda.js
@@ -46,9 +46,7 @@ function verifierPatternNom(nom) {
 }
 
 function verifierPatternURL(URL) {
-    const motifProtocol = /^https?:\/\//;
-    const motifDomain = /calendar\.google\.com/;
-    const motifFile = /\/basic\.ics$/;
+    const motifProtocol = /^http/;
     URL.style.borderColor = 'red'; // Bordure rouge en cas d'erreur
     var erreursURL = [];
 
@@ -58,16 +56,12 @@ function verifierPatternURL(URL) {
     }
 
     if (!motifProtocol.test(URL.value)) {
-        erreursURL.push('Le début de l\'URL doit être http ou https.');
-    } if (!motifDomain.test(URL.value)) {
-        erreursURL.push('L\'URL doit être celle de Google Calendar.');
-    } if (!motifFile.test(URL.value)) {
-        erreursURL.push('L\'URL doit pointer vers un fichier .ics.');
+        erreursURL.push('Le début de l\'URL doit être http/https.');
     }
 
     urlError.innerHTML = erreursURL.join('<br>');
 
-    if (motifDomain.test(URL.value) && motifFile.test(URL.value) && motifProtocol.test(URL.value)) {
+    if (motifProtocol.test(URL.value)) {
         URL.style.borderColor = ''; // Bordure par défaut (succès)
         urlError.textContent = '';
         return true;

--- a/js/formulaireModificationAgenda.js
+++ b/js/formulaireModificationAgenda.js
@@ -39,30 +39,24 @@ function verifierPatternNomAgenda(nomAgenda) {
 }
 
 function verifierPatternURLAgenda(urlAgenda) {
-    const motifProtocol = /^https?:\/\//;
-    const motifDomain = /calendar\.google\.com/;
-    const motifFile = /\/basic\.ics$/;
-    urlAgenda.style.borderColor = 'red'; // Bordure rouge en cas d'erreur
-    var erreursurlAgenda = [];
+    const motifProtocol = /^http/;
+    URL.style.borderColor = 'red'; // Bordure rouge en cas d'erreur
+    var erreursURL = [];
 
-    if(urlAgenda.value === '') {
-        urlAgendaError.textContent = 'Veuillez saisir une urlAgenda.';
+    if(URL.value === '') {
+        urlError.textContent = 'Veuillez saisir une URL.';
         return false;
     }
 
-    if (!motifProtocol.test(urlAgenda.value)) {
-        erreursurlAgenda.push('Le début de l\'urlAgenda doit être http ou https.');
-    } if (!motifDomain.test(urlAgenda.value)) {
-        erreursurlAgenda.push('L\'urlAgenda doit être celle de Google Calendar.');
-    } if (!motifFile.test(urlAgenda.value)) {
-        erreursurlAgenda.push('L\'urlAgenda doit pointer vers un fichier .ics.');
+    if (!motifProtocol.test(URL.value)) {
+        erreursURL.push('Le début de l\'URL doit être http/https.');
     }
 
-    urlAgendaError.innerHTML = erreursurlAgenda.join('<br>');
+    urlError.innerHTML = erreursURL.join('<br>');
 
-    if (motifDomain.test(urlAgenda.value) && motifFile.test(urlAgenda.value) && motifProtocol.test(urlAgenda.value)) {
-        urlAgenda.style.borderColor = ''; // Bordure par défaut (succès)
-        urlAgendaError.textContent = '';
+    if (motifProtocol.test(URL.value)) {
+        URL.style.borderColor = ''; // Bordure par défaut (succès)
+        urlError.textContent = '';
         return true;
     }
 }

--- a/modeles/utilitaire.class.php
+++ b/modeles/utilitaire.class.php
@@ -162,7 +162,6 @@ class utilitaire
      * @param string $urlAgenda L'URL de l'agenda
      * @param array $messagesErreurs Les messages d'erreurs que l'on pourra ajouter si erreur détectée
      * @return bool Retourne vrai si l'URL de l'agenda est valide, faux sinon
-     * @todo Modifier le regex pour accepter les URL Apple Calendar ?
      */
     public static function validerURLAgenda(?string $urlAgenda, array &$messagesErreurs): bool
     {
@@ -177,27 +176,40 @@ class utilitaire
         // 3. Longueur de la chaine - non pertinent
 
         // 4. Format des données : vérifier le format de l'URL
-        if (!filter_var($urlAgenda, FILTER_VALIDATE_URL) && !utilitaire::validerPreg($urlAgenda, '/^https?:\/\/calendar\.google\.com\/calendar\/ical\/.+\/basic\.ics$/', $messagesErreurs, "URL agenda")) {
+        if (!filter_var($urlAgenda, FILTER_VALIDATE_URL) && !utilitaire::validerPreg($urlAgenda, '/^http/', $messagesErreurs, "URL agenda")) {
             $messagesErreurs[] = "L'URL de l'agenda n'est pas valide.";
             $valide = false;
         } else {
             // Vérification du type MIME du fichier
-            $headers = get_headers($urlAgenda, 1);
-            if (!isset($headers['Content-Type'])) {
+            try {
+                // Récupère les en-têtes de l'URL (avec @ pour supprimer les avertissements)
+                @$headers = get_headers($urlAgenda, 1);
+            
+                // Vérifie si les en-têtes sont valides et si 'Content-Type' existe
+                if (!$headers || !isset($headers['Content-Type'])) {
+                    $messagesErreurs[] = "Impossible de récupérer les informations du fichier à partir de l'URL";
+                    $valide = false;
+                } else {
+                    // Vérifie si le type de contenu est 'text/calendar'
+                    if (strpos($headers['Content-Type'], 'text/calendar') === false) {
+                        $messagesErreurs[] = "Le fichier obtenu à partir de l'URL n'est pas un agenda";
+                        $valide = false;
+                    }
+                }
+            } catch (Exception $e) {
                 $messagesErreurs[] = "Impossible de vérifier le type du fichier à partir de l'URL";
-                $valide = false;
-            } elseif (strpos($headers['Content-Type'], 'text/calendar') === false) {
-                $messagesErreurs[] = "Le fichier obtenu à partir de l'URL n'est pas un agenda";
                 $valide = false;
             }
 
-            // Test de création de l'objet ICal à partir de l'URL
-            try {
-                // @ nécessaire pour enlever les erreurs
-                @$calendrier = new ICal($urlAgenda);
-            } catch (Exception $e) {
-                $messagesErreurs[] = "Impossible d'importer les données ";
-                $valide = false;
+            // Test de création de l'objet ICal à partir de l'URL si vérification précédente réussie
+            if ($valide) {
+                try {
+                    // @ nécessaire pour enlever les erreurs
+                    @$calendrier = new ICal($urlAgenda);
+                } catch (Exception $e) {
+                    $messagesErreurs[] = "Impossible d'importer les données ";
+                    $valide = false;
+                }
             }
         }
 


### PR DESCRIPTION
- Correction du message d'erreur php lorsqu'on donne un URL invalide causé par la méthode utilitaire::validerUrlAgenda() qui essayait de récupérer le header du fichier qui n'existe pas (en mettant l'instruction dans un bloc if/try)
- Simplication des vérification des URL pointant vers les fichiers ICS afin de permettre l'importation de fichier hors google. Il est désormais seulement vérifié que le lien commence par http* (dans tout les cas, on vérifie ensuite que le fichier peut être instancié par ICal donc pas de pblm de sécurité). Ces modifications affectent la méthode utilitaire::validerUrlAgenda() ainsi que le JS pour les pages de Création et Modification d'agenda