### PR TITLE
Ergonomie guidage importation

### DIFF
--- a/templates/agenda.html.twig
+++ b/templates/agenda.html.twig
@@ -37,7 +37,7 @@
                         <td>
                             <a role="button" href="#" data-bs-toggle="modal" data-bs-target="#fenetreModale{{ agenda.id }}">
                             <i class="fa-solid fa-pencil fa-2xl text-primary"></i></a>
-                            <a role="button" href="#" data-bs-toggle="modal" data-bs-target="#fenetreModaleSuppression{{ agenda.id }}" >
+                            <a role="button" href="#" data-bs-toggle="modal" data-bs-target="#fenetreModaleSuppression{{ agenda.id }}">
                             <i class="fa-solid fa-trash fa-2xl text-danger"></i></a>
                         </td>
                     </tr>
@@ -132,7 +132,11 @@
 						<div class="mb-3">
 							<label for="url" class="form-label">URL *</label>
 							<input type="url" name="url" class="form-control" id="url" required placeholder="Entrez une URL valide" title="Entrez l'URL valide de votre agenda Google.">
-                            <small id="urlError" class="text-danger"></small>
+                            <small id="urlError" class="text-danger"></small><br>
+                            <i class="fa-solid fa-circle-info text-info small me-1"></i>
+                            <a href="#" class="small text-info" data-bs-toggle="modal" data-bs-target="#modaleAideImportation">Où trouver le lien de mon agenda ?</a>
+
+
                         </div>
                         <div class="mb-3">
                             <label for="couleur" class="form-label">Couleur *</label><br>

--- a/templates/agenda.html.twig
+++ b/templates/agenda.html.twig
@@ -135,8 +135,6 @@
                             <small id="urlError" class="text-danger"></small><br>
                             <i class="fa-solid fa-circle-info text-info small me-1"></i>
                             <a href="#" class="small text-info" data-bs-toggle="modal" data-bs-target="#modaleAideImportation">Où trouver le lien de mon agenda ?</a>
-
-
                         </div>
                         <div class="mb-3">
                             <label for="couleur" class="form-label">Couleur *</label><br>
@@ -154,6 +152,110 @@
 					</form>
 				</div>
 			</div>
+            <!-- Fenêtre modale de guidage pour l'importation d'agendas-->
+            <div class="modal fade" id="modaleAideImportation" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal-dialog modal-lg">
+                    <div class="modal-content">
+                        <div class="modal-header bg-primary text-secondary">
+                            <h1 class="modal-title fs-5" id="exampleModalLabel">Où trouver le lien de mon agenda ?</h1>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="accordion" id="accordionAideImportation">
+          
+                                <!-- Google Agenda -->
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingGoogle">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseGoogle" aria-expanded="false" aria-controls="collapseGoogle">
+                                            <i class="fa-brands fa-google me-2"></i> Google Agenda 
+                                        </button>
+                                    </h2>
+                                    <div id="collapseGoogle" class="accordion-collapse collapse show" aria-labelledby="headingGoogle" data-bs-parent="#accordionAideImportation">
+                                        <div class="accordion-body">
+                                            1. Ouvrez <a href="https://calendar.google.com/" target="_blank">Google Agenda</a> sur un navigateur. <br>
+                                            2. Dans la colonne de gauche, passez la souris sur le calendrier que vous souhaitez partager et cliquez sur les trois points. <br>
+                                            3. Sélectionnez <strong>Paramètres et partage</strong>. <br>
+                                            4. Faites défiler jusqu’à <strong>Intégrer le calendrier</strong>. <br>
+                                            5. Copiez le lien ICS dans la section <strong>Adresse secrète au format iCal</strong> (nécessaire si le calendrier est privé). <br>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Outlook -->
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingOutlook">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOutlook" aria-expanded="false" aria-controls="collapseOutlook">
+                                            <i class="fa-brands fa-microsoft me-2"></i> Microsoft Outlook
+                                        </button>
+                                    </h2>
+                                    <div id="collapseOutlook" class="accordion-collapse collapse" aria-labelledby="headingOutlook" data-bs-parent="#accordionAideImportation">
+                                        <div class="accordion-body">
+                                            1. Allez sur <a href="https://outlook.live.com/" target="_blank">Outlook Web</a> et connectez-vous. <br>
+                                            2. Dans le menu de gauche, cliquez sur <strong>Paramètres</strong> (roue dentée). <br>
+                                            3. Recherchez <strong>Calendriers partagés</strong> et sélectionnez votre calendrier. <br>
+                                            4. Sous <strong>Publier un calendrier</strong>, choisissez <strong>Peut afficher tous les détails</strong>. <br>
+                                            5. Copiez le lien ICS généré sous <strong>Lien ICS</strong>. <br>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Apple Calendar -->
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingApple">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseApple" aria-expanded="false" aria-controls="collapseApple">
+                                            <i class="fa-brands fa-apple me-2"></i> Apple Calendar
+                                        </button>
+                                    </h2>
+                                    <div id="collapseApple" class="accordion-collapse collapse" aria-labelledby="headingApple" data-bs-parent="#accordionAideImportation">
+                                        <div class="accordion-body">
+                                            1. Ouvrez <a href="https://www.icloud.com/" target="_blank">iCloud.com</a> et connectez-vous. <br>
+                                            2. Accédez à <strong>Calendrier</strong>. <br>
+                                            3. Cliquez sur l’icône des options (à droite du nom du calendrier). <br>
+                                            4. Cochez <strong>Calendrier public</strong>. <br>
+                                            5. Copiez le lien ICS affiché. <br>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- Yahoo Calendar -->
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingYahoo">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseYahoo" aria-expanded="false" aria-controls="collapseYahoo">
+                                            <i class="fa-brands fa-yahoo me-2"></i> Yahoo Calendar
+                                        </button>
+                                    </h2>
+                                    <div id="collapseYahoo" class="accordion-collapse collapse" aria-labelledby="headingYahoo" data-bs-parent="#accordionAideImportation">
+                                        <div class="accordion-body">
+                                            1. Ouvrez <a href="https://calendar.yahoo.com/" target="_blank">Yahoo Calendar</a> et connectez-vous. <br>
+                                            2. Cliquez sur l’icône en forme d'engrenage en haut à droite et sélectionnez <strong>Paramètres</strong>. <br>
+                                            3. Accédez à l’onglet <strong>Calendriers</strong>, puis sélectionnez le calendrier à partager. <br>
+                                            4. Cochez <strong>Partager par lien</strong> et copiez le lien ICS généré. <br>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Autres plateformes -->
+                                <div class="accordion-item">
+                                    <h2 class="accordion-header" id="headingAutres">
+                                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseAutres" aria-expanded="false" aria-controls="collapseAutres">
+                                            <i class="fa-solid fa-calendar me-2"></i> Autres plateformes
+                                        </button>
+                                    </h2>
+                                    <div id="collapseAutres" class="accordion-collapse collapse" aria-labelledby="headingAutres" data-bs-parent="#accordionAideImportation">
+                                        <div class="accordion-body">
+                                            1. Ouvrez votre application ou service de calendrier et accédez aux paramètres. <br>
+                                            2. Recherchez une option de partage ou d'exportation de calendrier. <br>
+                                            3. Vérifiez si une option <strong>Partager via un lien ICS</strong> est disponible. <br>
+                                            4. Copiez le lien ICS fourni. <br>
+                                        </div>
+                                    </div>
+                                </div>
+
+                        {# <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                        </div> #}
+                    </div>
+                </div>
+            </div>
             {% endif %}
         <!-- Affichage des messages -->
         {% if message %}


### PR DESCRIPTION
Ajout d'un lien dans le formulaire d'importation d'un calendrier ouvrant une fenêtre modale expliquant comment trouver le lien ICS nécessaire en fonction du service utilisé (Google Agenda, Apple Calendar...)